### PR TITLE
Version in a separate file is overkill.

### DIFF
--- a/forecast_io.gemspec
+++ b/forecast_io.gemspec
@@ -1,11 +1,7 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-
-require 'forecast_io/version'
-
 Gem::Specification.new do |s|
   s.name        = "forecast_io"
-  s.version     = Forecast::IO::VERSION
+  s.version     = '1.1.0'
   s.authors     = ["David Czarnecki"]
   s.email       = ["me@davidczarnecki.com"]
   s.homepage    = "https://github.com/darkskyapp/forecast-ruby"

--- a/lib/forecast_io.rb
+++ b/lib/forecast_io.rb
@@ -1,5 +1,4 @@
 require 'forecast_io/configuration'
-require 'forecast_io/version'
 
 require 'hashie'
 require 'multi_json'

--- a/lib/forecast_io/version.rb
+++ b/lib/forecast_io/version.rb
@@ -1,6 +1,0 @@
-module Forecast
-  module IO
-    # Current Forecast::IO version
-    VERSION = '1.1.0'
-  end
-end

--- a/spec/forecast_io/version_spec.rb
+++ b/spec/forecast_io/version_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe 'Forecast::IO::VERSION' do
-  it 'should be the correct version' do
-    Forecast::IO::VERSION.should == '1.1.0'
-  end
-end


### PR DESCRIPTION
I used to take this approach, but these days I find just putting version numbers in gem specs is simple and effective. The odds of someone else writing code that relies on that version constant is pretty slim (and hopefully there's no reason for them to do so).

And yes, this is me being opinionated, so if you think this is a waste of time, no worries :)
