### PR TITLE
Changing Forecast::IO to ForecastIO to avoid naming collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ require 'forecast_io'
 You will need to set your API key before you can make requests to the [forecast.io](https://developer.darkskyapp.com/docs/v2) API.
 
 ```ruby
-Forecast::IO.configure do |configuration|
+ForecastIO.configure do |configuration|
   configuration.api_key = 'this-is-your-api-key'
 end
 ```
@@ -31,10 +31,10 @@ end
 Alternatively:
 
 ```ruby
-Forecast::IO.api_key = 'this-is-your-api-key'
+ForecastIO.api_key = 'this-is-your-api-key'
 ```
 
-You can then make requests to the `Forecast::IO.forecast(latitude, longitude, options = {})` method.
+You can then make requests to the `ForecastIO.forecast(latitude, longitude, options = {})` method.
 
 Valid options in the `options` hash are:
 
@@ -47,25 +47,25 @@ Valid options in the `options` hash are:
 Get the current forecast:
 
 ```ruby
-forecast = Forecast::IO.forecast(37.8267, -122.423)
+forecast = ForecastIO.forecast(37.8267, -122.423)
 ```
 
 Get the current forecast at a given time:
 
 ```ruby
-forecast = Forecast::IO.forecast(37.8267, -122.423, time: Time.new(2013, 3, 11).to_i)
+forecast = ForecastIO.forecast(37.8267, -122.423, time: Time.new(2013, 3, 11).to_i)
 ```
 
 Get the current forecast and use SI units:
 
 ```ruby
-forecast = Forecast::IO.forecast(37.8267, -122.423, params: { units: 'si' })
+forecast = ForecastIO.forecast(37.8267, -122.423, params: { units: 'si' })
 ```
 
 The `forecast(...)` method will return a response that you can interact with in a more-friendly way, such as:
 
 ```ruby
-forecast = Forecast::IO.forecast(37.8267, -122.423)
+forecast = ForecastIO.forecast(37.8267, -122.423)
 forecast.latitude
 forecast.longitude
 ```
@@ -91,7 +91,7 @@ Alternatively:
 ```ruby
 require 'typhoeus/adapters/faraday'
 
-Forecast::IO.connection = Faraday.new do |builder|
+ForecastIO.connection = Faraday.new do |builder|
   builder.adapter :typhoeus
 end
 ```
@@ -99,11 +99,11 @@ end
 You can also customise the default parameters passed through on each API call:
 
 ```ruby
-Forecast::IO.default_params = {units: 'si'}
+ForecastIO.default_params = {units: 'si'}
 
 # or
 
-Forecast::IO.configure do |configuration|
+ForecastIO.configure do |configuration|
   configuration.default_params = {units: 'si'}
 end
 ```

--- a/forecast_io.gemspec
+++ b/forecast_io.gemspec
@@ -5,7 +5,7 @@ require 'forecast_io/version'
 
 Gem::Specification.new do |s|
   s.name        = "forecast_io"
-  s.version     = Forecast::IO::VERSION
+  s.version     = ForecastIO::VERSION
   s.authors     = ["David Czarnecki"]
   s.email       = ["me@davidczarnecki.com"]
   s.homepage    = "https://github.com/darkskyapp/forecast-ruby"

--- a/lib/forecast_io.rb
+++ b/lib/forecast_io.rb
@@ -5,48 +5,46 @@ require 'hashie'
 require 'multi_json'
 require 'faraday'
 
-module Forecast
-  module IO
-    extend Configuration
+module ForecastIO
+  extend Configuration
 
-    self.default_params = {}
+  self.default_params = {}
 
-    class << self
-      # Retrieve the forecast for a given latitude and longitude.
-      #
-      # @param latitude [String] Latitude.
-      # @param longitude [String] Longitude.
-      # @param options [String] Optional parameters. Valid options are `:time` and `:params`.
-      def forecast(latitude, longitude, options = {})
-        forecast_url = "#{Forecast::IO.api_endpoint}/forecast/#{Forecast::IO.api_key}/#{latitude},#{longitude}"
-        forecast_url += ",#{options[:time]}" if options[:time]
+  class << self
+    # Retrieve the forecast for a given latitude and longitude.
+    #
+    # @param latitude [String] Latitude.
+    # @param longitude [String] Longitude.
+    # @param options [String] Optional parameters. Valid options are `:time` and `:params`.
+    def forecast(latitude, longitude, options = {})
+      forecast_url = "#{ForecastIO.api_endpoint}/forecast/#{ForecastIO.api_key}/#{latitude},#{longitude}"
+      forecast_url += ",#{options[:time]}" if options[:time]
 
-        forecast_response = get(forecast_url, options[:params])
+      forecast_response = get(forecast_url, options[:params])
 
-        if forecast_response.success?
-          return Hashie::Mash.new(MultiJson.load(forecast_response.body))
-        end
+      if forecast_response.success?
+        return Hashie::Mash.new(MultiJson.load(forecast_response.body))
       end
+    end
 
-      # Build or get an HTTP connection object.
-      def connection
-        @connection ||= Faraday.new
-      end
+    # Build or get an HTTP connection object.
+    def connection
+      @connection ||= Faraday.new
+    end
 
-      # Set an HTTP connection object.
-      #
-      # @param connection Connection object to be used.
-      def connection=(connection)
-        @connection = connection
-      end
+    # Set an HTTP connection object.
+    #
+    # @param connection Connection object to be used.
+    def connection=(connection)
+      @connection = connection
+    end
 
-      private
+    private
 
-      def get(path, params = {})
-        params = Forecast::IO.default_params.merge(params || {})
+    def get(path, params = {})
+      params = ForecastIO.default_params.merge(params || {})
 
-        connection.get(path, params)
-      end
+      connection.get(path, params)
     end
   end
 end

--- a/lib/forecast_io/configuration.rb
+++ b/lib/forecast_io/configuration.rb
@@ -1,38 +1,36 @@
-module Forecast
-  module IO
-    module Configuration
-      # Default API endpoint
-      DEFAULT_FORECAST_IO_API_ENDPOINT = 'https://api.forecast.io'
+module ForecastIO
+  module Configuration
+    # Default API endpoint
+    DEFAULT_FORECAST_IO_API_ENDPOINT = 'https://api.forecast.io'
 
-      # Forecast API endpoint
-      attr_writer :api_endpoint
+    # Forecast API endpoint
+    attr_writer :api_endpoint
 
-      # API key
-      attr_writer :api_key
+    # API key
+    attr_writer :api_key
 
-      # Default parameters
-      attr_accessor :default_params
+    # Default parameters
+    attr_accessor :default_params
 
-      # Yield self to be able to configure Forecast::IO with block-style configuration.
-      #
-      # Example:
-      #
-      #   Forecast::IO.configure do |configuration|
-      #     configuration.api_key = 'this-is-your-api-key'
-      #   end
-      def configure
-        yield self
-      end
+    # Yield self to be able to configure ForecastIO with block-style configuration.
+    #
+    # Example:
+    #
+    #   ForecastIO.configure do |configuration|
+    #     configuration.api_key = 'this-is-your-api-key'
+    #   end
+    def configure
+      yield self
+    end
 
-      # API endpoint
-      def api_endpoint
-        @api_endpoint ||= DEFAULT_FORECAST_IO_API_ENDPOINT
-      end
+    # API endpoint
+    def api_endpoint
+      @api_endpoint ||= DEFAULT_FORECAST_IO_API_ENDPOINT
+    end
 
-      # API key
-      def api_key
-        @api_key
-      end
+    # API key
+    def api_key
+      @api_key
     end
   end
 end

--- a/lib/forecast_io/version.rb
+++ b/lib/forecast_io/version.rb
@@ -1,6 +1,3 @@
-module Forecast
-  module IO
-    # Current Forecast::IO version
-    VERSION = '1.2.0'
-  end
+module ForecastIO
+  VERSION = '1.2.0'
 end

--- a/spec/forecast_io/configuration_spec.rb
+++ b/spec/forecast_io/configuration_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Forecast::IO::Configuration do
+describe ForecastIO::Configuration do
   describe '.configure' do
     it 'should have default attributes' do
-      Forecast::IO.configure do |configuration|
-        configuration.api_endpoint.should eql(Forecast::IO::Configuration::DEFAULT_FORECAST_IO_API_ENDPOINT)
+      ForecastIO.configure do |configuration|
+        configuration.api_endpoint.should eql(ForecastIO::Configuration::DEFAULT_FORECAST_IO_API_ENDPOINT)
         configuration.api_key.should be_nil
       end
     end

--- a/spec/forecast_io/forecast_io_spec.rb
+++ b/spec/forecast_io/forecast_io_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
-describe Forecast::IO do
+describe ForecastIO do
   describe '.default_params' do
     it "defaults to an empty hash" do
-      Forecast::IO.default_params.should == {}
+      ForecastIO.default_params.should == {}
     end
   end
 
   describe '.forecast' do
+    before :each do
+      ForecastIO.api_key = 'this-is-an-api-key'
+    end
+
     it 'should return a forecast for a given latitude, longitude' do
       VCR.use_cassette('forecast_for_latitude_longitude', record: :once) do
-        Forecast::IO.api_key = 'this-is-an-api-key'
-        forecast = Forecast::IO.forecast('37.8267','-122.423')
+        forecast = ForecastIO.forecast('37.8267','-122.423')
         forecast.should_not be_nil
         forecast.latitude.should == 37.8267
         forecast.longitude.should == -122.423
@@ -22,8 +25,7 @@ describe Forecast::IO do
 
     it 'should return a forecast for a given latitude, longitude and time' do
       VCR.use_cassette('forecast_for_latitude_longitude_and_time') do
-        Forecast::IO.api_key = 'this-is-an-api-key'
-        forecast = Forecast::IO.forecast('37.8267','-122.423', time: Time.utc(2013, 3, 11, 4).to_i)
+        forecast = ForecastIO.forecast('37.8267','-122.423', time: Time.utc(2013, 3, 11, 4).to_i)
         forecast.should_not be_nil
         forecast.latitude.should == 37.8267
         forecast.longitude.should == -122.423
@@ -34,8 +36,7 @@ describe Forecast::IO do
 
     it 'should return a forecast for a given latitude, longitude and query params' do
       VCR.use_cassette('forecast_for_latitude_longitude_and_query_params') do
-        Forecast::IO.api_key = 'this-is-an-api-key'
-        forecast = Forecast::IO.forecast('37.8267','-122.423', params: {units: 'si'})
+        forecast = ForecastIO.forecast('37.8267','-122.423', params: {units: 'si'})
         forecast.should_not be_nil
         forecast.latitude.should == 37.8267
         forecast.longitude.should == -122.423
@@ -51,12 +52,12 @@ describe Forecast::IO do
       before :each do
         stub_const 'Faraday', stub(new: faraday)
 
-        Forecast::IO.stub api_key: 'abc123', connection: faraday
+        ForecastIO.stub api_key: 'abc123', connection: faraday
       end
 
       context 'without default parameters' do
         before :each do
-          Forecast::IO.stub default_params: {}
+          ForecastIO.stub default_params: {}
         end
 
         it "sends through a standard request" do
@@ -64,7 +65,7 @@ describe Forecast::IO do
             'https://api.forecast.io/forecast/abc123/1.2,3.4', {}
           ).and_return response
 
-          Forecast::IO.forecast 1.2, 3.4
+          ForecastIO.forecast 1.2, 3.4
         end
 
         it "sends through provided parameters" do
@@ -72,13 +73,13 @@ describe Forecast::IO do
             'https://api.forecast.io/forecast/abc123/1.2,3.4', {units: 'si'}
           ).and_return response
 
-          Forecast::IO.forecast 1.2, 3.4, params: {units: 'si'}
+          ForecastIO.forecast 1.2, 3.4, params: {units: 'si'}
         end
       end
 
       context 'with default parameters' do
         before :each do
-          Forecast::IO.stub default_params: {units: 'si'}
+          ForecastIO.stub default_params: {units: 'si'}
         end
 
         it "sends through the default parameters" do
@@ -86,7 +87,7 @@ describe Forecast::IO do
             'https://api.forecast.io/forecast/abc123/1.2,3.4', {units: 'si'}
           ).and_return response
 
-          Forecast::IO.forecast 1.2, 3.4
+          ForecastIO.forecast 1.2, 3.4
         end
 
         it "sends through the merged parameters" do
@@ -95,7 +96,7 @@ describe Forecast::IO do
             {units: 'si', exclude: 'daily'}
           ).and_return response
 
-          Forecast::IO.forecast 1.2, 3.4, params: {exclude: 'daily'}
+          ForecastIO.forecast 1.2, 3.4, params: {exclude: 'daily'}
         end
 
         it "overwrites default parameters when appropriate" do
@@ -104,7 +105,7 @@ describe Forecast::IO do
             {units: 'imperial'}
           ).and_return response
 
-          Forecast::IO.forecast 1.2, 3.4, params: {units: 'imperial'}
+          ForecastIO.forecast 1.2, 3.4, params: {units: 'imperial'}
         end
       end
     end

--- a/spec/forecast_io/version_spec.rb
+++ b/spec/forecast_io/version_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'Forecast::IO::VERSION' do
+describe 'ForecastIO::VERSION' do
   it 'should be the correct version' do
-    Forecast::IO::VERSION.should == '1.2.0'
+    ForecastIO::VERSION.should == '1.2.0'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,6 @@ Faraday.default_adapter = :typhoeus
 
 RSpec.configure do |config|
   config.before(:each) do
-    Forecast::IO.api_key = nil
+    ForecastIO.api_key = nil
   end
 end


### PR DESCRIPTION
As discussed in an earlier comment, here's the pull request with the namespacing change.

Generally I feel gems should have namespaces matching their names, and make a reasonable attempt to avoid collisions with commonly named objects in others' code. Granted, this change will require a serious bump to the version number - probably to 2.0.

If you don't want to merge this in, keen to hear reasons why :)
