### PR TITLE
forecast.io to darksky.net api

### DIFF
--- a/lib/forecast_io/configuration.rb
+++ b/lib/forecast_io/configuration.rb
@@ -1,7 +1,7 @@
 module ForecastIO
   module Configuration
     # Default API endpoint
-    DEFAULT_FORECAST_IO_API_ENDPOINT = 'https://api.forecast.io'
+    DEFAULT_FORECAST_IO_API_ENDPOINT = 'https://api.darksky.net'
 
     # Forecast API endpoint
     attr_writer :api_endpoint


### PR DESCRIPTION
forecast.io has announced that they are rebranding as Darksky and are moving their API endpoint.

http://blog.darksky.net/introducing-darksky-net/