### PR TITLE
Add optional request read timeout to Faraday [Fixes #10]

### DIFF
--- a/lib/forecast_io.rb
+++ b/lib/forecast_io.rb
@@ -29,7 +29,7 @@ module ForecastIO
 
     # Build or get an HTTP connection object.
     def connection
-      @connection ||= Faraday.new
+      @connection ||= Faraday.new(request: { timeout: ForecastIO.timeout })
     end
 
     # Set an HTTP connection object.

--- a/lib/forecast_io/configuration.rb
+++ b/lib/forecast_io/configuration.rb
@@ -9,6 +9,9 @@ module ForecastIO
     # API key
     attr_writer :api_key
 
+    # Request read timeout
+    attr_writer :timeout
+
     # Default parameters
     attr_accessor :default_params
 
@@ -18,6 +21,7 @@ module ForecastIO
     #
     #   ForecastIO.configure do |configuration|
     #     configuration.api_key = 'this-is-your-api-key'
+    #     configuration.timeout = 500
     #   end
     def configure
       yield self
@@ -31,6 +35,11 @@ module ForecastIO
     # API key
     def api_key
       @api_key
+    end
+
+    # Request read timeout
+    def timeout
+      @timeout
     end
   end
 end

--- a/spec/forecast_io/configuration_spec.rb
+++ b/spec/forecast_io/configuration_spec.rb
@@ -6,6 +6,7 @@ describe ForecastIO::Configuration do
       ForecastIO.configure do |configuration|
         expect(configuration.api_endpoint).to eq(ForecastIO::Configuration::DEFAULT_FORECAST_IO_API_ENDPOINT)
         expect(configuration.api_key).to be_nil
+        expect(configuration.timeout).to be_nil
       end
     end
   end


### PR DESCRIPTION
Added an optional read timeout to the Faraday connection. The default behavior of allowing it to be nil is consistent with Faraday's default, just to call out one potential question. Thanks 🙏 